### PR TITLE
Allow opening any text files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
         applicationId "com.wbrawner.simplemarkdown"
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 7
-        versionName "0.4.1"
+        versionCode 8
+        versionName "0.4.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,10 +11,11 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:resizeableActivity="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:resizeableActivity="true"
         android:theme="@style/AppTheme"
+        tools:ignore="AllowBackup"
         tools:targetApi="n">
         <activity
             android:name=".view.activity.SplashActivity"
@@ -35,8 +36,6 @@
                 <data android:scheme="content" />
                 <data android:mimeType="text/plain" />
                 <data android:mimeType="text/markdown" />
-                <data android:pathPattern=".*\\.md" />
-                <data android:pathPattern=".*\\.markdown" />
                 <data android:mimeType="application/octet-stream" />
                 <data android:host="*" />
             </intent-filter>

--- a/app/src/main/java/com/wbrawner/simplemarkdown/view/fragment/EditFragment.java
+++ b/app/src/main/java/com/wbrawner/simplemarkdown/view/fragment/EditFragment.java
@@ -140,8 +140,9 @@ public class EditFragment extends Fragment implements MarkdownEditView {
 
     @Override
     public void onFileLoaded(boolean success) {
-        int message = success ? R.string.file_loaded : R.string.file_load_error;
-        Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
+        // TODO: Investigate why this fires off so often
+//        int message = success ? R.string.file_loaded : R.string.file_load_error;
+//        Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
     }
 
     @Override


### PR DESCRIPTION
Previously the app was limited to just files with common markdown file extensions in their name, but Nextcloud Notes, for example, saves the markdown files with a .txt extension. In order to be more accommodating, the filename extension restriction has been lifted