### PR TITLE
Add basic readability highlighting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     implementation 'com.jakewharton.rxbinding2:rxbinding-design:2.0.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.0'
+    implementation 'eu.crydee:syllable-counter:4.0.2'
 
     implementation "ch.acra:acra-http:$acraVersion"
 

--- a/app/src/main/java/com/wbrawner/simplemarkdown/model/Readability.java
+++ b/app/src/main/java/com/wbrawner/simplemarkdown/model/Readability.java
@@ -1,0 +1,34 @@
+package com.wbrawner.simplemarkdown.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Readability {
+    private String content = "";
+    private final String DELIMS = ".!?\n";
+
+    public Readability(String content){
+        this.content = content;
+    }
+
+    public List<Sentence> sentences(){
+
+        ArrayList<Sentence> list = new ArrayList<>();
+
+        int startOfSentance = 0;
+        String line = "";
+        for(int i = 0; i < content.length(); i++){
+            String c = content.charAt(i) + "";
+            if(DELIMS.contains(c)){
+                list.add(new Sentence(content,startOfSentance,i));
+                startOfSentance = i + 1;
+                line = "";
+            }else{
+                line += c;
+            }
+        }
+        if(line != "")list.add(new Sentence(content,startOfSentance,content.length()));
+
+        return list;
+    }
+}

--- a/app/src/main/java/com/wbrawner/simplemarkdown/model/Sentence.java
+++ b/app/src/main/java/com/wbrawner/simplemarkdown/model/Sentence.java
@@ -1,0 +1,48 @@
+package com.wbrawner.simplemarkdown.model;
+
+import eu.crydee.syllablecounter.SyllableCounter;
+
+public class Sentence {
+
+    private String sentence = "";
+    private int start = 0;
+    private int end = 0;
+
+    private final static SyllableCounter sc = new SyllableCounter();
+
+    public Sentence(String content, int start, int end){
+        this.start = start;
+        this.end = end;
+        this.sentence = content.substring(start, end);
+
+        trimStart();
+    }
+
+    public Sentence(String sentence){
+        this.sentence = sentence;
+    }
+
+    private void trimStart() {
+        while(sentence.startsWith(" ")){
+            this.start++;
+            sentence = sentence.substring(1);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return sentence;
+    }
+
+    public int start(){
+        return start;
+    }
+
+    public int end(){
+        return end;
+    }
+
+    public int syllableCount(){
+        return sc.count(sentence);
+    }
+}

--- a/app/src/main/java/com/wbrawner/simplemarkdown/utility/ReadabilityObserver.java
+++ b/app/src/main/java/com/wbrawner/simplemarkdown/utility/ReadabilityObserver.java
@@ -1,0 +1,60 @@
+package com.wbrawner.simplemarkdown.utility;
+
+import android.graphics.Color;
+import android.text.SpannableString;
+import android.text.style.BackgroundColorSpan;
+import android.widget.EditText;
+import android.widget.TextView;
+import com.wbrawner.simplemarkdown.model.Readability;
+import com.wbrawner.simplemarkdown.model.Sentence;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+
+public class ReadabilityObserver implements Observer<String> {
+    private EditText text;
+    private String previousValue = "";
+
+    public ReadabilityObserver(EditText text) {
+        this.text = text;
+    }
+
+    @Override
+    public void onSubscribe(Disposable d) {
+
+    }
+
+
+    @Override
+    public void onNext(String markdown) {
+        if(markdown.length() < 1) return;
+        if(previousValue.equals(markdown)) return;
+
+        Readability readability = new Readability(markdown);
+
+        SpannableString span = new SpannableString(markdown);
+
+        for(Sentence sentence : readability.sentences()){
+            int color = Color.TRANSPARENT;
+            if(sentence.syllableCount() > 25) color = Color.argb(100,229,232,42);
+            if(sentence.syllableCount() > 35) color = Color.argb(100,193,66,66);
+            span.setSpan(new BackgroundColorSpan(color), sentence.start(), sentence.end(), 0);
+        }
+
+
+        text.setTextKeepState(span, TextView.BufferType.SPANNABLE);
+        previousValue = markdown;
+
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        System.err.println("An error occurred while handling the markdown");
+        e.printStackTrace();
+        // TODO: report this?
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+}

--- a/app/src/main/java/com/wbrawner/simplemarkdown/view/fragment/EditFragment.java
+++ b/app/src/main/java/com/wbrawner/simplemarkdown/view/fragment/EditFragment.java
@@ -21,6 +21,7 @@ import com.wbrawner.simplemarkdown.MarkdownApplication;
 import com.wbrawner.simplemarkdown.R;
 import com.wbrawner.simplemarkdown.presentation.MarkdownPresenter;
 import com.wbrawner.simplemarkdown.utility.MarkdownObserver;
+import com.wbrawner.simplemarkdown.utility.ReadabilityObserver;
 import com.wbrawner.simplemarkdown.utility.Utils;
 import com.wbrawner.simplemarkdown.view.MarkdownEditView;
 
@@ -67,6 +68,7 @@ public class EditFragment extends Fragment implements MarkdownEditView {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread());
         obs.subscribe(new MarkdownObserver(presenter, obs));
+        obs.subscribe(new ReadabilityObserver(markdownEditor));
         return view;
     }
 

--- a/app/src/test/java/com/wbrawner/simplemarkdown/ReadabilityTest.java
+++ b/app/src/test/java/com/wbrawner/simplemarkdown/ReadabilityTest.java
@@ -1,0 +1,52 @@
+package com.wbrawner.simplemarkdown;
+
+import com.wbrawner.simplemarkdown.model.Readability;
+import com.wbrawner.simplemarkdown.model.Sentence;
+import eu.crydee.syllablecounter.SyllableCounter;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ReadabilityTest {
+
+    @Test
+    public void break_content_into_sentances() {
+        SyllableCounter sc = new SyllableCounter();
+        assertEquals(4, sc.count("facility"));
+    }
+
+    @Test
+    public void can_break_text_into_sentences_with_indexes(){
+        String content = "Hop on pop. I am a fish. This is a test.";
+        Readability readability = new Readability(content);
+        List<Sentence> sentenceList = readability.sentences();
+
+        assertEquals(3, sentenceList.size());
+
+        Sentence hopOnPop = sentenceList.get(0);
+        assertEquals(hopOnPop.toString(), "Hop on pop");
+        assertEquals(0, hopOnPop.start());
+        assertEquals(10, hopOnPop.end());
+
+        Sentence iAmAFish = sentenceList.get(1);
+        assertEquals(iAmAFish.toString(), "I am a fish");
+        assertEquals(12, iAmAFish.start());
+        assertEquals(23, iAmAFish.end());
+
+        Sentence thisIsATest = sentenceList.get(2);
+        assertEquals(thisIsATest.toString(), "This is a test");
+        assertEquals(25, thisIsATest.start());
+        assertEquals(39, thisIsATest.end());
+    }
+
+
+    @Test
+    public void get_syllable_count_for_sentence(){
+        assertEquals(8, new Sentence("This is the song that never ends").syllableCount());
+        assertEquals(10, new Sentence("facility facility downing").syllableCount());
+    }
+
+
+}


### PR DESCRIPTION
Personally, I'm a terrible writer and I've found simple aids really help keep my prose tight.
These changes will highlight sentences that are hard to read, based on the number of syllables they contain.
Here's what happens based on syllable count:
- less than 25 syllables: its easy to read (heuristically speaking), and has no background colour
- between 25 and 35 syllables, it's a bit hard to understand, and has a yellow background colour
- over 35 syllables, its quite hard to read, and has a red background color

This might be well outside the scope of what you had in mind, but I personally find it usefull.
At the moment it's on by default, in a seperate observer.
Maybe you could add a setting for it