### PR TITLE
README.md add translation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Simple Markdown is an open source Markdown editor.
      alt="Get it on F-Droid"
      height="80">](https://f-droid.org/packages/com.wbrawner.simplemarkdown.free/)
 
+
+## Translation
+
+Please help to translate on the [Weblate](https://toolate.othing.xyz/projects/simplemarkdown/).
+
+<a href="https://toolate.othing.xyz/projects/simplemarkdown/">
+<img src="https://toolate.othing.xyz/widget/simplemarkdown/multi-auto.svg" alt="Translation status" />
+</a>
+
+
 ## Building
 
 Using Android Studio is the preferred way to build the project. To build from the command line, you can run


### PR DESCRIPTION
We can integrate a translation service.
The https://toolate.othing.xyz/ based on Weblate, no pre-moderation, it can send a PR with translations, has automatic translations from Baidu. It's deployed specifically for the F-Droid apps

I created a translation project on the Toolate https://toolate.othing.xyz/projects/simplemarkdown/
and also made a testing translations and it sent you a PR #141.

If you are fine with the solution then please add the Toolate link to the README to help users to find it. Also if you wish I can send you an invitation to become an admin of the translation project (needed sometimes to resolve merge conflicts).

Thank you for the app!