### PR TITLE
Fix horizontal scrolling for tables

### DIFF
--- a/app/src/main/java/com/wbrawner/simplemarkdown/ui/MarkdownText.kt
+++ b/app/src/main/java/com/wbrawner/simplemarkdown/ui/MarkdownText.kt
@@ -90,9 +90,9 @@ fun MarkdownText(modifier: Modifier = Modifier, markdown: String) {
 @Composable
 fun HtmlText(html: String, modifier: Modifier = Modifier) {
     val materialColors = MaterialTheme.colorScheme
-    val style = remember(isSystemInDarkTheme()) {
+    val head = remember(isSystemInDarkTheme()) {
         val borderColor = materialColors.outline.toArgb().toHexString().substring(2)
-        """body {
+        val style = """body {
             |   background: #${materialColors.surface.toArgb().toHexString().substring(2)};
             |   color: #${materialColors.onSurface.toArgb().toHexString().substring(2)};
             |}
@@ -111,6 +111,8 @@ fun HtmlText(html: String, modifier: Modifier = Modifier) {
             |}
             |table {
             |   border-collapse: collapse;
+            |   display: block;
+            |   overflow-x: auto;
             |}
             |tr:nth-child(2n) {
             |   background-color: #${materialColors.surfaceDim.toArgb().toHexString().substring(2)};
@@ -119,6 +121,8 @@ fun HtmlText(html: String, modifier: Modifier = Modifier) {
             |   border: 1px solid #$borderColor;
             |   padding: 0.5em;
             |}""".trimMargin().wrapTag("style")
+        val viewport = """<meta name="viewport" content="width=device-width, initial-scale=1">"""
+        viewport + style
     }
     AndroidView(
         modifier = modifier,
@@ -139,14 +143,14 @@ fun HtmlText(html: String, modifier: Modifier = Modifier) {
                         setBackgroundColor(TRANSPARENT)
                         isNestedScrollingEnabled = false
                         settings.javaScriptEnabled = true
-                        loadDataWithBaseURL(null, style + html, "text/html", "UTF-8", null)
+                        loadDataWithBaseURL(null, head + html, "text/html", "UTF-8", null)
                     }
                 )
             }
         },
         update = { frameLayout ->
             frameLayout.findViewWithTag<WebView>(WEBVIEW_TAG)
-                .loadDataWithBaseURL(null, style + html, "text/html", "UTF-8", null)
+                .loadDataWithBaseURL(null, head + html, "text/html", "UTF-8", null)
         }
     )
 }


### PR DESCRIPTION
## Summary
- Adds `display: block` and `overflow-x: auto` CSS properties to the table element in the markdown preview so wide tables can be scrolled horizontally
- Adds a viewport meta tag (`width=device-width, initial-scale=1`) to ensure the WebView layout width matches the device screen, which is required for `overflow-x` to trigger correctly in Android WebView

Fixes #150

## Test plan
- [ ] Open a markdown file containing a wide table (many columns)
- [ ] Switch to preview mode
- [ ] Verify the table can be scrolled horizontally to see all columns
- [ ] Verify narrow tables still render normally
- [ ] Verify other content (text, code blocks, images) still renders correctly